### PR TITLE
A couple of fixes to preserve compatibility with 0.0.1

### DIFF
--- a/libraries/core.rb
+++ b/libraries/core.rb
@@ -244,13 +244,13 @@ module AFW
     # Inbound rules
     if direction == "in"
       iptables_header = "-A INPUT "
-      iptables_header << "-i #{interface}" unless interface.empty?
+      iptables_header << "-i #{interface}" unless interface.nil? or interface.empty?
       sources = expand_targets(node, source,options,name)
 
     # Outbound rules
     elsif direction == "out"
       iptables_header = "-A #{user}"
-      iptables_header << " -o #{interface}" unless interface.empty?
+      iptables_header << " -o #{interface}" unless interface.nil? or interface.empty?
       destinations = expand_targets(node, destination,options,name)
     end
 
@@ -318,7 +318,7 @@ module AFW
         if s_results.nil?
           results = []
         else
-          results = s_results.map{|n| n['network']['lanip'] || BLACKHOLE_IP}
+          results = s_results.map{|n| n['network']['lanip'] || n['ipaddress'] || BLACKHOLE_IP}
         end
       end
 


### PR DESCRIPTION
I just upgraded from 0.0.1, and these changes were necessary for my existing rules to work. They're straightforward and shouldn't break anything.

When looking at a rule, call both .nil? and .empty? on the interface key

In node search, check for IP address under ['ipaddress'] in addition to ['network']['lanip']
