### PR TITLE
Add iptables "--comment"

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,6 +3,9 @@ default['afw']['enable_input_drop'] = true
 default['afw']['enable_output_drop'] = false
 default['afw']['enable_input_drop_log'] = true
 default['afw']['enable_output_drop_log'] = true
+# Passes -m comment --comment "Rule Name Here" to iptables
+# On some platforms, you might need to load ipt_comment or xt_comment modules
+default['afw']['use_rule_comments'] = false
 
 # Default attributes, do not modify
 default['afw']['missing_user'] = false


### PR DESCRIPTION
Hi, small change to allow comments to be appended to rules,
makes the output of iptables -L ... easier to grok with lots of nodes/rules.

If set, iptables commands have -m comment --comment "Rule Name Here"
added, resulting in iptables -L output like this:

ACCEPT tcp -- 10.1.2.3 anywhere tcp dpt:http ctstate NEW /\* Allow all HTTP */
