### PR TITLE
Preventing auto cleanup of the rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ external tool perhaps.
 To disable automatic cleanup simply set this on the node:
 
 ```
-node['afw']['disable_cleanup'] = "the value does not matter"
+node['afw']['enable_rules_cleanup'] = false
 ```
 
 **Please remember:** You will have to remove unwanted rules manually.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,6 +22,8 @@ default['afw']['ruby_source'] = "gempackage"
 #default['afw']['ruby_source'] = "package"
 #default['afw']['ruby_source'] = "none"
 
+default['afw']['enable_rules_cleanup'] = true
+
 case platform
 when "centos","redhat","fedora"
   set['afw']['dnsruby_package_name'] = "rubygem-dnsruby"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -100,7 +100,7 @@ ruby_block 'cleanup_rules' do
     node.set['afw']['chains'] = {}
     node.set['afw']['tables'] = {}
   end
-  only_if { not node['afw'].has_key?('disable_cleanup') }
+  only_if { node['afw']['enable_rules_cleanup'] == true }
 end
 
 execute 'restore firewall' do


### PR DESCRIPTION
The rules on the Chef server node object will be removed upon successfull execution of the cookbook. The point of cleaning up is to avoid stale rules that could be deleted from the definitions (roles & cookbooks) but survive in the node attributes forever.

You can change this behaviour. One of the scenarios where you would like to do so would be applying the rules from outside of cookbooks, with an external tool perhaps.
