### PR TITLE
libraries.core: Convert the port number to a string

### DIFF
--- a/libraries/core.rb
+++ b/libraries/core.rb
@@ -194,7 +194,7 @@ module AFW
 
   def check_port(port, name)
     # check a (s|d)port against a regex
-    unless port =~ PORT_VALID_REGEX
+    unless port.to_s =~ PORT_VALID_REGEX
       raise ArgumentError, "Invalid Port '#{port}' in rule '#{name}'", caller
     end
     return true


### PR DESCRIPTION
Previously, when checking the port number against the regex, we
assumed that the port would always be a string.  When an integer
was passed to the check_port function it would blow up and fail
the chef-client run.

This change will convert the value passed to a string and then
attempt to run the regex against the value.

The offending value was passed like:

``` ruby
AFW.create_rule(node, 'Some rule', {
  'protocol' => 'tcp',
  'direction' => 'out',
  'user' => 'some_chump',
  'destination' => '127.0.0.1',
  'dport' => 8080
})
```
