### PR TITLE
recipes/default.rb: Initialize afw/rules attribute.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,6 +36,7 @@ elsif node['afw']['ruby_source'] == 'package'
   end
 end
 
+node.default['afw']['rules'] ||= {}
 node['afw']['rules'].each do |name,params|
   Chef::Log.info("AFW: processing rule '#{name}'")
   if process_rule(node, name, params)


### PR DESCRIPTION
`default['afw']['rules']` is not necessarily initialized before it is referenced in the default recipe.  This seems to only occur when running in chef solo.

Stacktrace:

```
Generated at Mon Aug 05 12:51:54 +0000 2013
NoMethodError: undefined method `each' for nil:NilClass
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/afw/recipes/default.rb:39:in `from_file'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/cookbook_version.rb:558:in `load_recipe'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/language_include_recipe.rb:46:in `load_recipe'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/language_include_recipe.rb:33:in `include_recipe'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/language_include_recipe.rb:27:in `each'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/language_include_recipe.rb:27:in `include_recipe'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/locust/recipes/default.rb:14:in `from_file'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/cookbook_version.rb:558:in `load_recipe'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/language_include_recipe.rb:46:in `load_recipe'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/language_include_recipe.rb:33:in `include_recipe'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/language_include_recipe.rb:27:in `each'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/mixin/language_include_recipe.rb:27:in `include_recipe'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/run_context.rb:79:in `load'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/run_context.rb:75:in `each'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/run_context.rb:75:in `load'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:198:in `setup_run_context'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:418:in `do_run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/client.rb:176:in `run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/solo.rb:230:in `run_application'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/solo.rb:218:in `loop'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application/solo.rb:218:in `run_application'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/../lib/chef/application.rb:70:in `run'
/opt/vagrant_ruby/lib/ruby/gems/1.8/gems/chef-10.14.2/bin/chef-solo:25
/opt/vagrant_ruby/bin/chef-solo:19:in `load'
/opt/vagrant_ruby/bin/chef-solo:19
```
