### PR TITLE
Fix DNS lookup including extra IPs

### DIFF
--- a/libraries/core.rb
+++ b/libraries/core.rb
@@ -316,7 +316,7 @@ module AFW
         require 'dnsruby'
         resolver = Dnsruby::Resolver.new
         response = resolver.query(target)
-        response.each_resource do |r|
+        response.each_answer do |r|
           if r.type.eql?('A')
             ips.push(r.address)
           end


### PR DESCRIPTION
Currently, specifying a rule with a FQDN does a DNS lookup which includes _all_ `A` records returned, including that of e.g. the DNS server itself. This leads to more ports being opened than expected.

This change limits results to the "Answer" section, which is what was probably intended.
