### PR TITLE
Ec2 privips

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email "julien@linuxwall.info"
 license          "All rights reserved"
 description      "Installs/Configures the Advanced FireWall"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.7"
+version          "0.0.8"


### PR DESCRIPTION
our normal rules don't apply between two ec2 nodes using the rfc2812 addresses

this change ensures private ips are added to the iptables rules alongside the public ipv4 IP for ec nodes.
