### PR TITLE
Updated upstart-firewall.conf for Ubuntu 14.04

### DIFF
--- a/files/ubuntu-14.04/upstart-firewall.conf
+++ b/files/ubuntu-14.04/upstart-firewall.conf
@@ -1,0 +1,15 @@
+# firewall - Firewall
+#
+description     "firewall"
+
+# Make sure we start after file systems and net devices are up
+start on (starting network-interface
+          or starting network-manager
+          or starting networking)
+
+stop on runlevel [!023456]
+
+console output
+
+pre-start exec /sbin/iptables-restore < /etc/firewall/rules.iptables
+post-stop exec /sbin/iptables-restore < /etc/firewall/empty.iptables


### PR DESCRIPTION
Ubuntu 14.04 has changed its init system so the previous upstart-firewall.conf no longer works, which will leave the firewall uninitialised until Chef runs after boot. 

I've added a new upstart-firewall.conf with its "start on" the same as UFW's.
